### PR TITLE
feat: add linux-arm64 target and make build workflow more syntatically consistent

### DIFF
--- a/.github/workflows/build-vsix.yml
+++ b/.github/workflows/build-vsix.yml
@@ -12,32 +12,40 @@ jobs:
       with:
         submodules: 'true'
         fetch-depth: '0'
-    - name: Download artifact - win32
-      id: download-win32
+    - name: Download artifact - windows-x86_64
+      id: download-windows-x86_64
       uses: dsaltares/fetch-gh-release-asset@master
       with:
         repo: shader-slang/slang
         file: 'slang-.*-windows-x86_64\.zip'
         target: "./"
         regex: true
-    - name: Download artifact - win-arm64
-      id: download-win-arm64
+    - name: Download artifact - windows-aarch64
+      id: download-windows-aarch64
       uses: dsaltares/fetch-gh-release-asset@master
       with:
         repo: shader-slang/slang
         file: 'slang-.*-windows-aarch64\.zip'
         target: "./"
         regex: true
-    - name: Download artifact - linux64
-      id: download-linux64
+    - name: Download artifact - linux-x86_64
+      id: download-linux-x86_64
       uses: dsaltares/fetch-gh-release-asset@master
       with:
         repo: shader-slang/slang
         file: 'slang-.*-linux-x86_64\.zip'
         target: "./"
         regex: true
-    
-    - name: Download artifact - macos
+    - name: Download artifact - linux-aarch64
+      id: download-linux-aarch64
+      uses: dsaltares/fetch-gh-release-asset@master
+      with:
+        repo: shader-slang/slang
+        file: 'slang-.*-linux-aarch64\.zip'
+        target: "./"
+        regex: true
+    - name: Download artifact - macos-x86_64
+      id: download-macos-x86_64
       uses: dsaltares/fetch-gh-release-asset@master
       with:
         repo: shader-slang/slang
@@ -45,6 +53,7 @@ jobs:
         target: "./"
         regex: true
     - name: Download artifact - macos-aarch64
+      id: download-macos-aarch64
       uses: dsaltares/fetch-gh-release-asset@master
       with:
         repo: shader-slang/slang
@@ -53,12 +62,13 @@ jobs:
         regex: true
     - name: Copy Slang binaries and Build VSIX
       run: |
-        export TAGNAME=${{ steps.download-win32.outputs.version}}
-        export WIN32ZIP=slang-${TAGNAME:1}-windows-x86_64.zip
-        export WINARMZIP=slang-${TAGNAME:1}-windows-aarch64.zip
-        export LINUX64ZIP=slang-${TAGNAME:1}-linux-x86_64.zip
-        export MACOSX64ZIP=slang-${TAGNAME:1}-macos-x86_64.zip
-        export MACOSAARCH64ZIP=slang-${TAGNAME:1}-macos-aarch64.zip
+        export TAGNAME=${{ steps.download-windows-x86_64.outputs.version }}
+        export WIN32_X64_ZIP=slang-${TAGNAME:1}-windows-x86_64.zip
+        export WIN32_ARM64_ZIP=slang-${TAGNAME:1}-windows-aarch64.zip
+        export LINUX_X64_ZIP=slang-${TAGNAME:1}-linux-x86_64.zip
+        export LINUX_ARM64_ZIP=slang-${TAGNAME:1}-linux-aarch64.zip
+        export DARWIN_X64_ZIP=slang-${TAGNAME:1}-macos-x86_64.zip
+        export DARWIN_ARM64_ZIP=slang-${TAGNAME:1}-macos-aarch64.zip
         source build-package.sh
 
         for file in ./*.vsix

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish VSIX
+name: Publish VSIX - GitHub
 
 on:
   push:
@@ -13,32 +13,40 @@ jobs:
       with:
         submodules: 'true'
         fetch-depth: '0'
-    - name: Download artifact - win32
-      id: download-win32
+    - name: Download artifact - windows-x86_64
+      id: download-windows-x86_64
       uses: dsaltares/fetch-gh-release-asset@master
       with:
         repo: shader-slang/slang
         file: 'slang-.*-windows-x86_64\.zip'
         target: "./"
         regex: true
-    - name: Download artifact - win-arm64
-      id: download-win-arm64
+    - name: Download artifact - windows-aarch64
+      id: download-windows-aarch64
       uses: dsaltares/fetch-gh-release-asset@master
       with:
         repo: shader-slang/slang
         file: 'slang-.*-windows-aarch64\.zip'
         target: "./"
         regex: true
-    - name: Download artifact - linux64
-      id: download-linux64
+    - name: Download artifact - linux-x86_64
+      id: download-linux-x86_64
       uses: dsaltares/fetch-gh-release-asset@master
       with:
         repo: shader-slang/slang
         file: 'slang-.*-linux-x86_64\.zip'
         target: "./"
         regex: true
-    
-    - name: Download artifact - macos
+    - name: Download artifact - linux-aarch64
+      id: download-linux-aarch64
+      uses: dsaltares/fetch-gh-release-asset@master
+      with:
+        repo: shader-slang/slang
+        file: 'slang-.*-linux-aarch64\.zip'
+        target: "./"
+        regex: true
+    - name: Download artifact - macos-x86_64
+      id: download-macos-x86_64
       uses: dsaltares/fetch-gh-release-asset@master
       with:
         repo: shader-slang/slang
@@ -46,6 +54,7 @@ jobs:
         target: "./"
         regex: true
     - name: Download artifact - macos-aarch64
+      id: download-macos-aarch64
       uses: dsaltares/fetch-gh-release-asset@master
       with:
         repo: shader-slang/slang
@@ -54,27 +63,35 @@ jobs:
         regex: true
     - name: Copy Slang binaries and Build VSIX
       run: |
-        export TAGNAME=${{ steps.download-win32.outputs.version}}
-        export WIN32ZIP=slang-${TAGNAME:1}-windows-x86_64.zip
-        export WINARMZIP=slang-${TAGNAME:1}-windows-aarch64.zip
-        export LINUX64ZIP=slang-${TAGNAME:1}-linux-x86_64.zip
-        export MACOSX64ZIP=slang-${TAGNAME:1}-macos-x86_64.zip
-        export MACOSAARCH64ZIP=slang-${TAGNAME:1}-macos-aarch64.zip
+        export TAGNAME=${{ steps.download-windows-x86_64.outputs.version }}
+        export WIN32_X64_ZIP=slang-${TAGNAME:1}-windows-x86_64.zip
+        export WIN32_ARM64_ZIP=slang-${TAGNAME:1}-windows-aarch64.zip
+        export LINUX_X64_ZIP=slang-${TAGNAME:1}-linux-x86_64.zip
+        export LINUX_ARM64_ZIP=slang-${TAGNAME:1}-linux-aarch64.zip
+        export DARWIN_X64_ZIP=slang-${TAGNAME:1}-macos-x86_64.zip
+        export DARWIN_ARM64_ZIP=slang-${TAGNAME:1}-macos-aarch64.zip
         source build-package.sh
 
         for file in ./*.vsix
         do
           echo "Built VSIX: $file"
         done
-    - name: Publish VSIX package
-      env:
-        VSCE_TOKEN: ${{ secrets.VS_MARKETPLACE_TOKEN }}
-      run: |
-        for file in ./*.vsix
-        do
-          vsce publish -p "$VSCE_TOKEN" --packagePath "$file"
-        done
-        
+    - uses: actions/cache/save@v4
+      id: cache
+      with:
+        path: ./*.vsix
+        key: cache-${{ github.run_id }}-${{ github.run_attempt }}
+
+  publish-github:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+    - uses: actions/cache/restore@v4
+      id: cache
+      with:
+        path: ./*.vsix
+        key: cache-${{ github.run_id }}-${{ github.run_attempt }}
+        fail-on-cache-miss: true
     - name: UploadSource
       uses: softprops/action-gh-release@v1
       with:
@@ -82,3 +99,25 @@ jobs:
           *.vsix
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-vscode:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+    - uses: actions/cache/restore@v4
+      id: cache
+      with:
+        path: ./*.vsix
+        key: cache-${{ github.run_id }}-${{ github.run_attempt }}
+        fail-on-cache-miss: true
+    - name: Publish VSIX package to Visual Studio Marketplace
+      env:
+        VSCE_TOKEN: ${{ secrets.VS_MARKETPLACE_TOKEN }}
+      run: |
+        npm install -g @vscode/vsce
+
+        for file in ./*.vsix
+        do
+          vsce publish -p "$VSCE_TOKEN" --packagePath "$file"
+          echo "Published VSIX: $file"
+        done

--- a/build-package.sh
+++ b/build-package.sh
@@ -3,27 +3,27 @@ npm install -g @vscode/vsce
 
 ls ./
 mkdir -p ./tmp
-echo "extracting $WIN32ZIP"
-unzip -n $WIN32ZIP -d ./tmp
-mkdir -p ./server/bin/win-x64
-cp ./tmp/bin/slang.dll ./server/bin/win-x64/slang.dll
-cp ./tmp/bin/slangd.exe ./server/bin/win-x64/slangd.exe
+echo "extracting $WIN32_X64_ZIP"
+unzip -n $WIN32_X64_ZIP -d ./tmp
+mkdir -p ./server/bin/win32-x64
+cp ./tmp/bin/slang.dll ./server/bin/win32-x64/slang.dll
+cp ./tmp/bin/slangd.exe ./server/bin/win32-x64/slangd.exe
 vsce package --target win32-x64
 rm -rf ./tmp
 
 mkdir -p ./tmp
-echo "extracting $WINARMZIP"
-unzip -n $WINARMZIP -d ./tmp
+echo "extracting $WIN32_ARM64_ZIP"
+unzip -n $WIN32_ARM64_ZIP -d ./tmp
 rm -rf ./server/bin/
-mkdir -p ./server/bin/win-arm64
-cp ./tmp/bin/slang.dll ./server/bin/win-arm64/slang.dll
-cp ./tmp/bin/slangd.exe ./server/bin/win-arm64/slangd.exe
+mkdir -p ./server/bin/win32-arm64
+cp ./tmp/bin/slang.dll ./server/bin/win32-arm64/slang.dll
+cp ./tmp/bin/slangd.exe ./server/bin/win32-arm64/slangd.exe
 vsce package --target win32-arm64
 rm -rf ./tmp
 
 mkdir -p ./tmp
-echo "extracting $LINUX64ZIP"
-unzip -n $LINUX64ZIP -d ./tmp
+echo "extracting $LINUX_X64_ZIP"
+unzip -n $LINUX_X64_ZIP -d ./tmp
 rm -rf ./server/bin/
 mkdir -p ./server/bin/linux-x64
 cp ./tmp/lib/libslang.so ./server/bin/linux-x64/libslang.so
@@ -33,8 +33,19 @@ vsce package --target linux-x64
 rm -rf ./tmp
 
 mkdir -p ./tmp
-echo "extracting $MACOSX64ZIP"
-unzip -n $MACOSX64ZIP -d ./tmp
+echo "extracting $LINUX_ARM64_ZIP"
+unzip -n $LINUX_ARM64_ZIP -d ./tmp
+rm -rf ./server/bin/
+mkdir -p ./server/bin/linux-arm64
+cp ./tmp/lib/libslang.so ./server/bin/linux-arm64/libslang.so
+cp ./tmp/bin/slangd ./server/bin/linux-arm64/slangd
+chmod +x ./server/bin/linux-arm64/slangd
+vsce package --target linux-arm64
+rm -rf ./tmp
+
+mkdir -p ./tmp
+echo "extracting $DARWIN_X64_ZIP"
+unzip -n $DARWIN_X64_ZIP -d ./tmp
 rm -rf ./server/bin/
 mkdir -p ./server/bin/darwin-x64
 cp ./tmp/lib/libslang.dylib ./server/bin/darwin-x64/libslang.dylib
@@ -44,8 +55,8 @@ vsce package --target darwin-x64
 rm -rf ./tmp
 
 mkdir -p ./tmp
-echo "extracting $MACOSAARCH64ZIP"
-unzip -n $MACOSAARCH64ZIP -d ./tmp
+echo "extracting $DARWIN_ARM64_ZIP"
+unzip -n $DARWIN_ARM64_ZIP -d ./tmp
 rm -rf ./server/bin/
 mkdir -p ./server/bin/darwin-arm64
 cp ./tmp/lib/libslang.dylib ./server/bin/darwin-arm64/libslang.dylib

--- a/build-package.sh
+++ b/build-package.sh
@@ -1,66 +1,33 @@
 npm install
 npm install -g @vscode/vsce
 
-ls ./
-mkdir -p ./tmp
-echo "extracting $WIN32_X64_ZIP"
-unzip -n $WIN32_X64_ZIP -d ./tmp
-mkdir -p ./server/bin/win32-x64
-cp ./tmp/bin/slang.dll ./server/bin/win32-x64/slang.dll
-cp ./tmp/bin/slangd.exe ./server/bin/win32-x64/slangd.exe
-vsce package --target win32-x64
-rm -rf ./tmp
+target_build() {
+  TEMP_DIR="$(mktemp -d)"
+  ZIP="$1"
+  TARGET="$2"
+  TEMP_LIBRARY="$3"
+  TEMP_EXECUTABLE="$4"
 
-mkdir -p ./tmp
-echo "extracting $WIN32_ARM64_ZIP"
-unzip -n $WIN32_ARM64_ZIP -d ./tmp
-rm -rf ./server/bin/
-mkdir -p ./server/bin/win32-arm64
-cp ./tmp/bin/slang.dll ./server/bin/win32-arm64/slang.dll
-cp ./tmp/bin/slangd.exe ./server/bin/win32-arm64/slangd.exe
-vsce package --target win32-arm64
-rm -rf ./tmp
+  echo "extracting $ZIP"
+  unzip -n "$ZIP" -d "$TEMP_DIR"
 
-mkdir -p ./tmp
-echo "extracting $LINUX_X64_ZIP"
-unzip -n $LINUX_X64_ZIP -d ./tmp
-rm -rf ./server/bin/
-mkdir -p ./server/bin/linux-x64
-cp ./tmp/lib/libslang.so ./server/bin/linux-x64/libslang.so
-cp ./tmp/bin/slangd ./server/bin/linux-x64/slangd
-chmod +x ./server/bin/linux-x64/slangd
-vsce package --target linux-x64
-rm -rf ./tmp
+  echo "installing binaries for $TARGET"
+  mkdir -p "./server/bin/$TARGET"
+  cp "$TEMP_DIR/$TEMP_LIBRARY" ./server/bin/"$TARGET"/
+  cp "$TEMP_DIR/$TEMP_EXECUTABLE" ./server/bin/"$TARGET"/
+  chmod +x ./server/bin/"$TARGET"/*
 
-mkdir -p ./tmp
-echo "extracting $LINUX_ARM64_ZIP"
-unzip -n $LINUX_ARM64_ZIP -d ./tmp
-rm -rf ./server/bin/
-mkdir -p ./server/bin/linux-arm64
-cp ./tmp/lib/libslang.so ./server/bin/linux-arm64/libslang.so
-cp ./tmp/bin/slangd ./server/bin/linux-arm64/slangd
-chmod +x ./server/bin/linux-arm64/slangd
-vsce package --target linux-arm64
-rm -rf ./tmp
+  echo "building for $TARGET"
+  vsce package --target "$TARGET"
 
-mkdir -p ./tmp
-echo "extracting $DARWIN_X64_ZIP"
-unzip -n $DARWIN_X64_ZIP -d ./tmp
-rm -rf ./server/bin/
-mkdir -p ./server/bin/darwin-x64
-cp ./tmp/lib/libslang.dylib ./server/bin/darwin-x64/libslang.dylib
-cp ./tmp/bin/slangd ./server/bin/darwin-x64/slangd
-chmod +x ./server/bin/darwin-x64/slangd
-vsce package --target darwin-x64
-rm -rf ./tmp
+  echo "cleanup for $TARGET"
+  rm -rf $TEMP_DIR
+  rm -rf ./server/bin/
+}
 
-mkdir -p ./tmp
-echo "extracting $DARWIN_ARM64_ZIP"
-unzip -n $DARWIN_ARM64_ZIP -d ./tmp
-rm -rf ./server/bin/
-mkdir -p ./server/bin/darwin-arm64
-cp ./tmp/lib/libslang.dylib ./server/bin/darwin-arm64/libslang.dylib
-cp ./tmp/bin/slangd ./server/bin/darwin-arm64/slangd
-chmod +x ./server/bin/darwin-arm64/slangd
-vsce package --target darwin-arm64
-rm -rf ./tmp
+target_build "$WIN32_X64_ZIP" win32-x64 bin/slang.dll bin/slangd.exe
+target_build "$WIN32_ARM64_ZIP" win32-arm64 bin/slang.dll bin/slangd.exe
+target_build "$LINUX_X64_ZIP" linux-x64 lib/libslang.so bin/slangd
+target_build "$LINUX_ARM64_ZIP" linux-arm64 lib/libslang.so bin/slangd
+target_build "$DARWIN_X64_ZIP" darwin-x64 lib/libslang.dylib bin/slangd
+target_build "$DARWIN_ARM64_ZIP" darwin-arm64 lib/libslang.dylib bin/slangd

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -16,12 +16,10 @@ import {
 let client: LanguageClient;
 
 export function activate(context: ExtensionContext) {
-	const slangdLoc = workspace.getConfiguration("slang").get(
-		"slangdLocation",
-		context.asAbsolutePath(
-			path.join('server', 'bin', process.platform + '-' + process.arch, 'slangd')
-		)
-	);
+	let slangdLoc = workspace.getConfiguration("slang").get("slangdLocation", "");
+	if (slangdLoc === "") slangdLoc = context.asAbsolutePath(
+		path.join('server', 'bin', process.platform + '-' + process.arch, 'slangd')
+	)
 	const serverModule = slangdLoc;
 	const serverOptions: ServerOptions = {
 		run : { command: serverModule, transport: TransportKind.stdio},

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -16,24 +16,12 @@ import {
 let client: LanguageClient;
 
 export function activate(context: ExtensionContext) {
-	var platformDirName: string = "win";
-	var arch = process.arch;
-	var slangdLoc: string = workspace.getConfiguration("slang").get("slangdLocation", "");
-	if (slangdLoc == "") {
-		if (process.platform == 'win32') {
-			platformDirName = "win";
-		}
-		else if (process.platform == 'darwin') {
-			platformDirName = "darwin";
-			if (arch != 'arm64')
-				arch = 'x64';
-		}
-		else {
-			platformDirName = "linux";
-			arch = 'x64';
-		}
-		slangdLoc = context.asAbsolutePath(path.join('server', 'bin', platformDirName + '-' + arch, 'slangd'));
-	}
+	const slangdLoc = workspace.getConfiguration("slang").get(
+		"slangdLocation",
+		context.asAbsolutePath(
+			path.join('server', 'bin', process.platform + '-' + process.arch, 'slangd')
+		)
+	);
 	const serverModule = slangdLoc;
 	const serverOptions: ServerOptions = {
 		run : { command: serverModule, transport: TransportKind.stdio},


### PR DESCRIPTION
This pr has the objective to simplify the build and publish workflows simpler, making the addition of additional targets easier.

The way that this was archived was by modifying the extensions path loading to be simpler, using only `process.platform` and `process.arch` to determine the binary path instead of more complicated logic found previously.

This simplification of the path loading and adding of lead to the modification of the build script to fix the only change to the path with windows and to add the `linux-arm64`.

This lead to the renaming of the environment variables expected of the script to ones that more closely align with the release files from the https://github.com/shader-slang/slang repository.

And lastly, I rewrote the publish workflow with a more modular approach in mind, where the build files are cached for that workflow and then used for publishing on both GitHub Releases and the Visual Studio Marketplace. 

With this, the process to add new architectures or platforms is now way simpler, only needing to modify the build script and build workflow to include the extra target.

The workflow in this PR will probably not run considering the missing macos binary releases from the main repo, however, all changes were tested locally on my Linux x86_64 machine and worked correctly. I was not able to test with a arm machine or a windows machine to see if there were any regressions.