### PR TITLE
feat: add Open VSX deploy job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -121,3 +121,25 @@ jobs:
           vsce publish -p "$VSCE_TOKEN" --packagePath "$file"
           echo "Published VSIX: $file"
         done
+
+  publish-openvsx:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+    - uses: actions/cache/restore@v4
+      id: cache
+      with:
+        path: ./*.vsix
+        key: cache-${{ github.run_id }}-${{ github.run_attempt }}
+        fail-on-cache-miss: true
+    - name: Publish VSIX package to Open VSX
+      env:
+        OVSX_TOKEN: ${{ secrets.OPEN_VSX_TOKEN }}
+      run: |
+        npm install -g ovsx
+
+        for file in ./*.vsix
+        do
+          ovsx publish -p "$OVSX_TOKEN" --packagePath "$file"
+          echo "Published VSIX: $file"
+        done


### PR DESCRIPTION
This pr adds a extra deploy job to the workflow that publishes the extension to Open VSX. This will need intervention from the extension maintainers, listed below:

- [x] Creating a Eclipse Foundation account.
- [x] Signing the Open VSX Publishing Agreement.
- [x] Create the `shader-slang` namespace.
- [x] Add the Open VSX token to the `OPEN_VSX_TOKEN` GitHub Secret.

Documentation for the above steps can be found here (https://github.com/eclipse/openvsx/wiki/Publishing-Extensions).

Otherwise, the publish step should be automated, running alongside the other publish targets using the same cached files.

Adding the extension to the Open VSX ensures people using OSS versions of VSCode are able to make use of the extension without extra work and with automatic updates as you'd get in the Microsoft Licensed version of VSCode with the Visual Studio Marketplace.