### PR TITLE
Fix validation errors in syntax definition

### DIFF
--- a/syntaxes/slang.tmLanguage.json
+++ b/syntaxes/slang.tmLanguage.json
@@ -2794,7 +2794,7 @@
 		]
 	  },
 	  "probably_a_parameter": {
-		"match": "(?<=(?:[a-zA-Z_0-9] |[&*>\\]\\)]))\\s*([a-zA-Z_]\\w*)\\s*(?=(?:\\[\\]\\s*)?(?:,|\\)))",
+		"match": "(?<=[a-zA-Z_0-9] |[&*>\\]\\)])\\s*([a-zA-Z_]\\w*)\\s*(?=(?:\\[\\]\\s*)?(?:,|\\)))",
 		"captures": {
 		  "1": {
 			"name": "variable.parameter.probably.slang"
@@ -3007,18 +3007,6 @@
 					  }
 					},
 					"patterns": [
-					  {
-						"include": "source.asm"
-					  },
-					  {
-						"include": "source.x86"
-					  },
-					  {
-						"include": "source.x86_64"
-					  },
-					  {
-						"include": "source.arm"
-					  },
 					  {
 						"include": "#backslash_escapes"
 					  },


### PR DESCRIPTION
I'm trying to add Slang to [GitHub Linguist](https://github.com/github-linguist/linguist) (so that slang source files in github repositories will have syntax highlighting), but it had a couple of complaints about the syntax definition:

- In the `probably_a_parameter` rule, there was a non-capturing group wrapped in a lookbehind assertion, which was causing a `malformed regex: lookbehind assertion is not fixed length` error. I believe the non-capturing group was redundant anyway and can be removed.
- The syntax was referencing grammars for inline x86 assembly - I assume these were mistakenly copied from a C/C++ syntax definition?