### PR TITLE
Add (experimental missing keywords `constexpr` `dyn` `some`

### DIFF
--- a/syntaxes/slang.tmLanguage.json
+++ b/syntaxes/slang.tmLanguage.json
@@ -32,7 +32,7 @@
 	  },
 	  {
 		"name": "keyword.other.additional.slang",
-		"match": "\\b(throws|using|__generic|func|associatedtype|public|internal|private|import|module|implementing|__include|export|__exported|groupshared|let|var|property|extension|in|out|inout|ref|namespace|this|cbuffer|tbuffer|(dynamic_)?uniform|typealias|new|__extern_cpp|__(target|stage)_intrinsic|__intrinsic_asm|spirv_asm|(__)?(f|b)wd_diff|__dispatch_kernel|no_diff|__constref|expand|each|where|typename)\\b"
+		"match": "\\b(throws|using|__generic|func|associatedtype|public|internal|private|import|module|implementing|__include|export|__exported|groupshared|let|var|property|extension|in|out|inout|ref|namespace|this|cbuffer|tbuffer|(dynamic_)?uniform|typealias|new|__extern_cpp|__(target|stage)_intrinsic|__intrinsic_asm|spirv_asm|(__)?(f|b)wd_diff|__dispatch_kernel|no_diff|__constref|expand|each|where|typename|constexpr|dyn|some)\\b"
 	  },
 	  {
 		"match": "\\b(const|extern|register|restrict|static|volatile|inline|nointerpolation|precise|row_major|column_major|snorm|unorm|globallycoherent|layout)\\b",


### PR DESCRIPTION
Add missing keywords `constexpr` `dyn` `some`
fixes: #22