### PR TITLE
Add grammer for raypayload decoration and raypayload variable qualifiers

### DIFF
--- a/syntaxes/slang.tmLanguage.json
+++ b/syntaxes/slang.tmLanguage.json
@@ -463,7 +463,7 @@
 			  },
 			  {
 				"name": "meta.variable.qualifer",
-				"begin":"(?x) (\\b([a-zA-Z_][a-zA-Z_0-9]*)\\b)\\s*(?=:\\s*(.+))",
+				"begin":"(?x) (\\b([a-zA-Z_][a-zA-Z_0-9]*)\\b)\\s*(?=:\\s*((read|write).*))",
 				"beginCaptures": {
 					"1": {
 						"name": "variable.other.slang"


### PR DESCRIPTION
fixes: https://github.com/shader-slang/slang/issues/7336
Image of syntax added `[raypayload]`, `: read(...)`, and `: write(...)` is attached below. Given with the image is code which could cause an ambiguous clash of grammer.

![image](https://github.com/user-attachments/assets/93d35cc3-c22b-4584-a1f3-f2dfa0be45ae)
