### PR TITLE
Small fix for playground compilation error

### DIFF
--- a/server/src/compiler.ts
+++ b/server/src/compiler.ts
@@ -95,7 +95,7 @@ export class SlangCompiler {
 					log: error.message.toString(),
 				};
 			}
-			return entryPoint;
+			return { succ: true, result: entryPoint };
 		}
 	}
 


### PR DESCRIPTION
The findEntryPoint method in this spot is returning a raw Module object instead of wrapping it in a Result<Module> structure like elsewhere in the code. This is causing a lot of "unknown" playground compilation errors in the vsc extension.

With this change, things appear to be working correctly locally. 