### PR TITLE
Add extension server's playground.slang to Lang Server known files

### DIFF
--- a/client/src/nativeClientMain.ts
+++ b/client/src/nativeClientMain.ts
@@ -123,10 +123,13 @@ export async function activate(context: ExtensionContext) {
 		workspace.registerTextDocumentContentProvider('slang-synth', synthCodeProvider)
 	);
 
+	// Initialize language server options, including the implicit playground.slang file.
+	const playgroundUri = vscode.Uri.file(path.join(context.extensionPath, 'server', 'src', 'slang', 'playground.slang'));
+	const playgroundDocument = await vscode.workspace.openTextDocument(playgroundUri);
 	const initializationOptions: ServerInitializationOptions = {
 		extensionUri: context.extensionUri.toString(true),
-		workspaceUris: vscode.workspace.workspaceFolders.map(folder => folder.uri.fsPath),
-		files: await getSlangFilesWithContents(),
+		workspaceUris: vscode.workspace.workspaceFolders ? vscode.workspace.workspaceFolders.map(folder => folder.uri.fsPath) : [],
+		files: [... await getSlangFilesWithContents(), {uri: playgroundUri.toString(), content: playgroundDocument.getText() }]
 	}
 	worker = new Worker(path.join(context.extensionPath, 'server', 'dist', 'nativeServerMain.js'), {
 		workerData: initializationOptions


### PR DESCRIPTION
Enables syntax highlighting for structures defined in playground.slang even when no such file exists within the workspaces in the current editor. 

The path I'm using for resolution is based off `context.extensionPath`, which seems to adapt depending on if you're locally developing, or have installed the extension locally through a vsix. 

Example screenshot below with an empty workspace, where slangd is giving highlighting for playground attributes from import playground;

<img width="1300" height="745" alt="image" src="https://github.com/user-attachments/assets/55b24e95-1bfe-4bf7-8b88-f1c62fcced9d" />

