### PR TITLE
Look for `slangd` on `PATH` as a fallback

### DIFF
--- a/client/src/native/slangd.ts
+++ b/client/src/native/slangd.ts
@@ -1,4 +1,4 @@
-
+import * as fs from 'fs';
 import * as path from 'path';
 import { workspace, ExtensionContext } from 'vscode';
 
@@ -7,7 +7,7 @@ export function getSlangdLocation(context: ExtensionContext): string {
     if (slangdLoc === "") slangdLoc = context.asAbsolutePath(
         path.join('server', 'bin', process.platform + '-' + process.arch, 'slangd')
     );
-    return slangdLoc;
+    return fs.existsSync(slangdLoc) ? slangdLoc : 'slangd';
 }
 
 export function getBuiltinModuleCode(context: ExtensionContext, moduleName: string): Promise<string>  {

--- a/package.json
+++ b/package.json
@@ -166,8 +166,7 @@
                 "slang.slangdLocation": {
                     "scope": "machine-overridable",
                     "type": "string",
-                    "default": "",
-                    "markdownDescription": "The location of Slang's language server executable `slangd`. Will use bundled language server when unspecified."
+                    "markdownDescription": "The location of Slang's language server executable `slangd`. If left unspecified, will use bundled language server if present, otherwise will attempt to find `slangd` under `PATH`."
                 },
                 "slang.format.clangFormatStyle": {
                     "scope": "window",


### PR DESCRIPTION
Currently, if someone tries to run this extension locally (i.e. in a non-browser context) on a platform for which the extension does not come with prebuilt Slang binaries (or, similarly, when [installing via Nix](https://wiki.nixos.org/wiki/Visual_Studio_Code)), it fails when trying to open a Slang file:

> Slang Language Server client: couldn't create connection to server.

This is because the extension currently makes the incorrect assumption that "running natively" is the same as "there exists a bundled `slangd`". It is possible to work around this e.g. by creating a `.vscode/settings.json` file like this:

```json
{ "slang.slangdLocation": "slangd" }
```

But it would be more convenient if this extension looked for `slangd` on `PATH` by default as a fallback, which is what this PR does.