### PR TITLE
Update build scripts for emsdk 4.0.11 compatibility, pin that release for CI use

### DIFF
--- a/.github/actions/build-wasm-deps/action.yml
+++ b/.github/actions/build-wasm-deps/action.yml
@@ -15,7 +15,7 @@ runs:
         sudo apt-get update
         sudo apt-get install -y ninja-build
         if [ ! -d "emsdk" ]; then
-          git clone https://github.com/emscripten-core/emsdk.git
+          git clone --branch 4.0.11 https://github.com/emscripten-core/emsdk.git
           sed -i 's/\r$//' emsdk/emsdk emsdk/emsdk_env.sh
         fi
 

--- a/.github/actions/build-wasm-deps/action.yml
+++ b/.github/actions/build-wasm-deps/action.yml
@@ -14,10 +14,7 @@ runs:
       run: |
         sudo apt-get update
         sudo apt-get install -y ninja-build
-        if [ ! -d "emsdk" ]; then
-          git clone --branch 4.0.11 https://github.com/emscripten-core/emsdk.git
-          sed -i 's/\r$//' emsdk/emsdk emsdk/emsdk_env.sh
-        fi
+        source ./build_scripts/setup-emsdk.sh
 
     - name: get slang head commit
       shell: bash
@@ -30,12 +27,7 @@ runs:
     - name: get spirv-tool head commit
       shell: bash
       run: |
-        if [ ! -d "spirv-tools" ]; then
-          git clone https://github.com/KhronosGroup/SPIRV-Tools.git spirv-tools
-          pushd spirv-tools
-          git checkout vulkan-sdk-1.3.290.0
-          popd
-        fi
+        source ./build_scripts/setup-spirv-tools.sh
         git -C spirv-tools rev-parse HEAD > key-spirv-tool.txt
 
     - name: restore slang-wasm

--- a/build_scripts/setup-emsdk.sh
+++ b/build_scripts/setup-emsdk.sh
@@ -7,10 +7,3 @@ echo "[$(date)] Setup emsdk ..."
 if [ ! -d emsdk ]; then
 	git clone --branch $EMSDK_TAG --depth 1 https://github.com/emscripten-core/emsdk.git
 fi
-
-pushd emsdk
-	sed -i 's/\r$//' emsdk emsdk_env.sh
-	/bin/sh ./emsdk install latest
-	/bin/sh ./emsdk activate latest
-	source ./emsdk_env.sh
-popd 

--- a/build_scripts/setup-emsdk.sh
+++ b/build_scripts/setup-emsdk.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Shared script to setup emsdk with pinned version
+EMSDK_TAG="4.0.11"
+
+echo "[$(date)] Setup emsdk ..."
+if [ ! -d emsdk ]; then
+	git clone --branch $EMSDK_TAG --depth 1 https://github.com/emscripten-core/emsdk.git
+fi
+
+pushd emsdk
+	sed -i 's/\r$//' emsdk emsdk_env.sh
+	/bin/sh ./emsdk install latest
+	/bin/sh ./emsdk activate latest
+	source ./emsdk_env.sh
+popd 

--- a/build_scripts/setup-spirv-tools.sh
+++ b/build_scripts/setup-spirv-tools.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Shared script to setup SPIRV Tools with pinned version
+SPIRV_TOOLS_TAG="vulkan-sdk-1.3.290.0"
+
+echo "[$(date)] Setup SPIRV Tools ..."
+if [ ! -d spirv-tools ]; then
+	git clone https://github.com/KhronosGroup/SPIRV-Tools.git spirv-tools
+fi
+
+pushd spirv-tools
+	git checkout $SPIRV_TOOLS_TAG
+popd 

--- a/build_scripts/slang-wasm-build.sh
+++ b/build_scripts/slang-wasm-build.sh
@@ -12,18 +12,8 @@ do
 	fi
 done
 
-echo "[$(date)] Sync emsdk repo ..."
-if [ ! -d emsdk ]
-then
-	git clone https://github.com/emscripten-core/emsdk.git
-fi
-
-pushd emsdk
-	sed -i 's/\r$//' emsdk emsdk_env.sh
-	/bin/sh ./emsdk install latest
-	/bin/sh ./emsdk activate latest
-	source ./emsdk_env.sh
-popd
+# Setup emsdk using shared script
+source ./build_scripts/setup-emsdk.sh
 
 echo "[$(date)] Sync slang repo ..."
 if [ ! -d slang-repo ]

--- a/build_scripts/slang-wasm-build.sh
+++ b/build_scripts/slang-wasm-build.sh
@@ -12,8 +12,15 @@ do
 	fi
 done
 
-# Setup emsdk using shared script
+# Setup pinned emsdk version using shared script
 source ./build_scripts/setup-emsdk.sh
+
+pushd emsdk
+	sed -i 's/\r$//' emsdk emsdk_env.sh
+	/bin/sh ./emsdk install latest
+	/bin/sh ./emsdk activate latest
+	source ./emsdk_env.sh
+popd
 
 echo "[$(date)] Sync slang repo ..."
 if [ ! -d slang-repo ]

--- a/build_scripts/slang-wasm-build.sh
+++ b/build_scripts/slang-wasm-build.sh
@@ -46,7 +46,7 @@ sed -i '/^[[:space:]]*target_link_options(/,/^[[:space:]]*)/c\
         -sMODULARIZE=1\
         -sEXPORT_ES6=0\
     	-sSINGLE_FILE=1\
-  		-sENVIRONMENT="worker"\
+  		-sENVIRONMENT=worker\
         -sEXPORTED_RUNTIME_METHODS=['FS']\
     )' "source/slang-wasm/CMakeLists.txt"
 
@@ -107,7 +107,7 @@ sed -i '/^[[:space:]]*target_link_options(/,/^[[:space:]]*)/c\
         -sMODULARIZE=1\
         -sEXPORT_ES6=0\
         -sSINGLE_FILE=1\
-        -sENVIRONMENT="node"\
+        -sENVIRONMENT=node\
         -sEXPORTED_RUNTIME_METHODS=['FS']\
     )' "source/slang-wasm/CMakeLists.txt"
 

--- a/build_scripts/spirv-tool-wasm-build.sh
+++ b/build_scripts/spirv-tool-wasm-build.sh
@@ -24,7 +24,7 @@ python3 utils/git-sync-deps
 
 # add an additional option to emcc command
 sed -i 's/\r$//' source/wasm/build.sh
-sed -i 's/-s MODULARIZE \\/-s MODULARIZE -s SINGLE_FILE -s ENVIRONMENT="worker"\\/' source/wasm/build.sh
+sed -i 's/-s MODULARIZE \\/-s MODULARIZE -s SINGLE_FILE -s ENVIRONMENT=worker\\/' source/wasm/build.sh
 
 bash -x source/wasm/build.sh
 
@@ -37,7 +37,7 @@ cp ../spirv-tools.d.ts ../spirv-tools.worker.d.ts
 
 # --- Build for Node.js ---
 # Patch build.sh for Node.js build
-sed -i 's/-s ENVIRONMENT="worker"/-s ENVIRONMENT="node"/' source/wasm/build.sh
+sed -i 's/-s ENVIRONMENT=worker/-s ENVIRONMENT=node/' source/wasm/build.sh
 
 bash -x source/wasm/build.sh
 

--- a/build_scripts/spirv-tool-wasm-build.sh
+++ b/build_scripts/spirv-tool-wasm-build.sh
@@ -1,24 +1,12 @@
 #!/bin/bash
 
-if [ ! -d emsdk ]
-then
-    git clone https://github.com/emscripten-core/emsdk.git emsdk
-fi
+# Setup emsdk using shared script
+source ./build_scripts/setup-emsdk.sh
 
-pushd emsdk
-	sed -i 's/\r$//' emsdk emsdk_env.sh
-	/bin/sh ./emsdk install latest
-	/bin/sh ./emsdk activate latest
-	source ./emsdk_env.sh
-popd
-
-if [ ! -d spirv-tools ]
-then
-	git clone https://github.com/KhronosGroup/SPIRV-Tools.git spirv-tools
-fi
+# Setup SPIRV Tools using shared script
+source ./build_scripts/setup-spirv-tools.sh
 
 pushd spirv-tools
-git checkout vulkan-sdk-1.3.290.0
 
 python3 utils/git-sync-deps
 

--- a/build_scripts/spirv-tool-wasm-build.sh
+++ b/build_scripts/spirv-tool-wasm-build.sh
@@ -1,9 +1,16 @@
 #!/bin/bash
 
-# Setup emsdk using shared script
+# Setup pinned emsdk version using shared script
 source ./build_scripts/setup-emsdk.sh
 
-# Setup SPIRV Tools using shared script
+pushd emsdk
+	sed -i 's/\r$//' emsdk emsdk_env.sh
+	/bin/sh ./emsdk install latest
+	/bin/sh ./emsdk activate latest
+	source ./emsdk_env.sh
+popd
+
+# Setup pinned SPIRV Tools version using shared script
 source ./build_scripts/setup-spirv-tools.sh
 
 pushd spirv-tools


### PR DESCRIPTION
Fixes #42

The newest release of emsdk, [4.0.11] (https://github.com/emscripten-core/emsdk/commit/d49219d03a41cd12f95a33ba84273c20d41fd350) now expects lists for the ENVIRONMENT setting, whereas before it would accept strings. The slang-vscode-extension build scripts use quotes around the values set for ENVIRONMENT, causing them to be treated as strings and now rejected, breaking our CI builds.

This change removes the quotes around the value that we set for ENVIRONMENT, so that instead of being treated as strings, they are treated as single element lists. The CI successfully builds in my fork with this change: https://github.com/aidanfnv/slang-vscode-extension/actions/runs/16357356706
It also changes the CI action to checkout the 4.0.11 release of emsdk instead of the latest commit to prevent future updates to emsdk from breaking our CI.