### PR TITLE
Expand vscode vars in slang.additionalSearchPaths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+# Unreleased
+- Expand VS Code variables (for example `${workspaceFolder}`) in `slang.additionalSearchPaths`.
+
 # v2.0.7
 - Update to Slang v2026.3.1.
 - Fixes crash on incomplete import statements

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ You can specifiy the set of predefined preprocessor macros that the language ser
 ### Additional Search Path
 
 By default, the extension will search for all sub directories in the current workspace for an included or imported file. You can specify additional search paths via the `slang.additionalSearchPaths` setting, which will be looked at first. You can also disable the search in workspace directories and make the extension to search only in configured search paths (via `slang.searchInAllWorkspaceDirectories`). The path of the currently opend file will always be used.
+This setting supports VS Code variables such as `${workspaceFolder}`.
 
 ### Commit characters for auto completion
 

--- a/client/src/browserClientMain.ts
+++ b/client/src/browserClientMain.ts
@@ -5,6 +5,7 @@ import { LanguageClientOptions } from 'vscode-languageclient';
 import { LanguageClient } from 'vscode-languageclient/browser';
 import type { CompiledPlayground, CompileRequest, EntrypointsRequest, EntrypointsResult, Result, ServerInitializationOptions, Shader } from 'slang-playground-shared';
 import { getSlangFilesWithContents, sharedActivate } from './sharedClient';
+import { expandSlangSettingsInConfiguration } from './configVariables';
 
 let client: LanguageClient;
 
@@ -23,6 +24,23 @@ export async function activate(context: ExtensionContext) {
 		documentSelector,
 		synchronize: {},
 		initializationOptions,
+		middleware: {
+			workspace: {
+				configuration: async (params, token, next) => {
+					const values = await next(params, token);
+					if (!Array.isArray(values)) {
+						return values;
+					}
+					return values.map((value, index) =>
+						expandSlangSettingsInConfiguration(
+							value,
+							params.items[index]?.section,
+							params.items[index]?.scopeUri,
+						)
+					);
+				},
+			},
+		},
 	};
 
 	client = createWorkerLanguageClient(context, clientOptions);

--- a/client/src/configVariables.ts
+++ b/client/src/configVariables.ts
@@ -1,0 +1,119 @@
+import * as vscode from 'vscode';
+
+function getWorkspaceFolder(scopeUri?: string): vscode.WorkspaceFolder | undefined {
+	if (scopeUri) {
+		try {
+			const uri = vscode.Uri.parse(scopeUri);
+			const folder = vscode.workspace.getWorkspaceFolder(uri);
+			if (folder) {
+				return folder;
+			}
+			// Valid URI, but not mapped to a workspace folder (for example untitled:/virtual URIs).
+			// Continue to the single-root fallback below.
+		} catch {
+			// Ignore invalid scope URI and fall back to workspace-level behavior below.
+		}
+	}
+
+	// Some workspace/configuration requests are window-scoped and do not carry a scope URI.
+	// In a single-root workspace, using the lone folder preserves expected ${workspaceFolder} expansion.
+	const folders = vscode.workspace.workspaceFolders;
+	if (folders && folders.length === 1) {
+		return folders[0];
+	}
+
+	// In no-folder or multi-root workspaces, leave ${workspaceFolder}-style variables unresolved.
+	return undefined;
+}
+
+function getProcessLike(): NodeJS.Process | undefined {
+	return typeof process !== 'undefined' ? process : undefined;
+}
+
+function resolvePathSeparator(scopeUri?: string): string {
+	const workspaceFolder = getWorkspaceFolder(scopeUri);
+	if (workspaceFolder?.uri.fsPath.includes('\\')) {
+		return '\\';
+	}
+	const proc = getProcessLike();
+	return proc?.platform === 'win32' ? '\\' : '/';
+}
+
+function resolveVariable(variableName: string, scopeUri?: string): string | undefined {
+	const workspaceFolder = getWorkspaceFolder(scopeUri);
+	// Handle built-in variables with exact names.
+	switch (variableName) {
+		case 'workspaceFolder':
+		case 'workspaceRoot':
+			return workspaceFolder?.uri.fsPath;
+		case 'workspaceFolderBasename':
+		case 'workspaceRootFolderName':
+			return workspaceFolder?.name;
+		case 'pathSeparator':
+			return resolvePathSeparator(scopeUri);
+		case 'userHome': {
+			const proc = getProcessLike();
+			return proc?.env.HOME ?? proc?.env.USERPROFILE;
+		}
+		case 'cwd': {
+			const proc = getProcessLike();
+			return proc?.cwd ? proc.cwd() : undefined;
+		}
+		default:
+			break;
+	}
+
+	// Handle variables that encode an argument after a prefix, e.g. ${env:HOME}.
+	if (variableName.startsWith('workspaceFolder:')) {
+		const folderName = variableName.slice('workspaceFolder:'.length);
+		return vscode.workspace.workspaceFolders?.find(folder => folder.name === folderName)?.uri.fsPath;
+	}
+	if (variableName.startsWith('env:')) {
+		const envName = variableName.slice('env:'.length);
+		const proc = getProcessLike();
+		return proc?.env[envName];
+	}
+	if (variableName.startsWith('config:')) {
+		const settingName = variableName.slice('config:'.length);
+		// Resolve config values against the provided scope URI when available.
+		let scope: vscode.Uri | undefined;
+		if (scopeUri) {
+			try {
+				scope = vscode.Uri.parse(scopeUri);
+			} catch {
+				scope = undefined;
+			}
+		}
+		const settingValue = vscode.workspace.getConfiguration(undefined, scope).get<string>(settingName);
+		return settingValue;
+	}
+	return undefined;
+}
+
+export function expandVscodeVariables(value: string, scopeUri?: string): string {
+	return value.replace(/\$\{([^}]+)\}/g, (match, variableName) => {
+		const resolvedValue = resolveVariable(variableName, scopeUri);
+		return resolvedValue === undefined ? match : resolvedValue;
+	});
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+export function expandSlangSettingsInConfiguration(value: unknown, section?: string, scopeUri?: string): unknown {
+	if (section === 'slang.additionalSearchPaths' && Array.isArray(value)) {
+		return value.map(path => typeof path === 'string' ? expandVscodeVariables(path, scopeUri) : path);
+	}
+	if (section !== 'slang' || !isRecord(value)) {
+		return value;
+	}
+
+	const expandedSlangConfig: Record<string, unknown> = { ...value };
+	if (Array.isArray(expandedSlangConfig.additionalSearchPaths)) {
+		expandedSlangConfig.additionalSearchPaths = expandedSlangConfig.additionalSearchPaths.map(path =>
+			typeof path === 'string' ? expandVscodeVariables(path, scopeUri) : path
+		);
+	}
+	return expandedSlangConfig;
+}

--- a/client/src/nativeClientMain.ts
+++ b/client/src/nativeClientMain.ts
@@ -14,6 +14,7 @@ import { CompiledPlayground, CompileRequest, EntrypointsRequest, EntrypointsResu
 import { getSlangdLocation } from './native/slangd';
 import { SlangSynthesizedCodeProvider } from './native/synth_doc_provider';
 import { getSlangFilesWithContents, sharedActivate } from './sharedClient';
+import { expandSlangSettingsInConfiguration } from './configVariables';
 
 let client: LanguageClient;
 let worker: Worker;
@@ -68,6 +69,23 @@ export async function activate(context: ExtensionContext) {
 	const clientOptions: LanguageClientOptions = {
 		// Register the server for plain text documents
 		documentSelector: [{ scheme: 'file', language: 'slang' }],
+		middleware: {
+			workspace: {
+				configuration: async (params, token, next) => {
+					const values = await next(params, token);
+					if (!Array.isArray(values)) {
+						return values;
+					}
+					return values.map((value, index) =>
+						expandSlangSettingsInConfiguration(
+							value,
+							params.items[index]?.section,
+							params.items[index]?.scopeUri,
+						)
+					);
+				},
+			},
+		},
 	};
 
 	// Create the language client and start the client.

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
                     "items": {"type": "string"},
                     "examples": [["include/", "c:\\external-lib\\include"]],
                     "default": [],
-                    "description": "The language server will search for the included or imported file in these additional directories first. If not found, the server will look in all sub directories in the current workspace (if enabled by the setting)."
+                    "description": "The language server will search for the included or imported file in these additional directories first. If not found, the server will look in all sub directories in the current workspace (if enabled by the setting). Supports VS Code variables such as ${workspaceFolder}."
                 },
                 "slang.enableCommitCharactersInAutoCompletion": {
                     "scope": "window",


### PR DESCRIPTION
Hullo! This PR adds support for expanding VS Code variables (e.g. `${workspaceFolder}`) in `slang.additionalSearchPaths` before settings are sent to the language server.

_Disclaimer: the code was written by GPT-5.3-Codex._ I personally don't speak much TypeScript, and I don't have any experience developing VS Code extensions, so I can't exactly vouch for the architectural choices. FWIW, the code looks somewhat sane to me, and it passed multiple separate rounds of Codex-driven reviews. I've also tested the modified extension locally in a large workspace on Linux.

Codex-generated description follows:

What changed:
- Add config variable expansion utility in client/src/configVariables.ts
- Hook workspace/configuration middleware in native and browser clients to
  expand slang.additionalSearchPaths values
- Document variable support in package.json setting description and README
- Add changelog entry under Unreleased

Notes:
- Multi-root behavior is intentionally rudimentary; unresolved workspace-scoped
  variables are left unchanged when scope is ambiguous.
- No unit tests were added (project currently has none); behavior was verified
  externally.

Part of #47