### PR TITLE
[codex] fix string highlighting after static assert

### DIFF
--- a/syntaxes/slang.tmLanguage.json
+++ b/syntaxes/slang.tmLanguage.json
@@ -833,7 +833,7 @@
       "patterns": [
         {
           "name": "meta.qualified.type.call.slang",
-          "begin": "(?x)\\b((?:String|Array|Tuple|Optional|Conditional|Result|Ptr|ImmutablePtr|Atomic|DescriptorHandle|DifferentialPair|ParameterBlock|ConstantBuffer|TextureBuffer|SamplerState|SamplerComparisonState|SubpassInput|SubpassInputMS|RaytracingAccelerationStructure|(?:(?:Depth|Feedback|RasterizerOrdered|RW)?Texture(?:1D|2D|3D|Cube)(?:Array)?(?:MS(?:Array)?)?|Sampler(?:1D|2D|3D|Cube)(?:Array)?(?:Shadow)?|(?:Append|Consume|RW)?StructuredBuffer|(?:RW)?Buffer|(?:RW|RasterizerOrdered)?ByteAddressBuffer)|__[_A-Za-z0-9]*Type|[A-Z][A-Za-z_0-9]*))\\b(?=\\s*(?:<[^;\\n]*>)?\\s*(?:\\.|::)[^;\\n]*\\b[A-Za-z_][A-Za-z_0-9]*\\b\\s*(?:<[^{};\\n]*>\\s*)?\\()",
+          "begin": "(?x)\\b((?:String|Array|Tuple|Optional|Conditional|Result|Ptr|ImmutablePtr|Atomic|DescriptorHandle|DifferentialPair|ParameterBlock|ConstantBuffer|TextureBuffer|SamplerState|SamplerComparisonState|SubpassInput|SubpassInputMS|RaytracingAccelerationStructure|(?:(?:Depth|Feedback|RasterizerOrdered|RW)?Texture(?:1D|2D|3D|Cube)(?:Array)?(?:MS(?:Array)?)?|Sampler(?:1D|2D|3D|Cube)(?:Array)?(?:Shadow)?|(?:Append|Consume|RW)?StructuredBuffer|(?:RW)?Buffer|(?:RW|RasterizerOrdered)?ByteAddressBuffer)|__[_A-Za-z0-9]*Type|[A-Z][A-Za-z_0-9]*))\\b(?=\\s*(?:<[^;\\n]*>)?\\s*(?:\\.|::)[^;\"'\\n]*\\b[A-Za-z_][A-Za-z_0-9]*\\b\\s*(?:<[^{};\\n]*>\\s*)?\\()",
           "beginCaptures": {
             "1": {
               "name": "entity.name.type.slang"
@@ -1811,7 +1811,7 @@
               "name": "punctuation.definition.string.begin.slang"
             }
           },
-          "end": "(?<!\\\\)\"",
+          "end": "\"|$",
           "endCaptures": {
             "0": {
               "name": "punctuation.definition.string.end.slang"
@@ -1831,7 +1831,7 @@
               "name": "punctuation.definition.string.begin.slang"
             }
           },
-          "end": "(?<!\\\\)'",
+          "end": "'|$",
           "endCaptures": {
             "0": {
               "name": "punctuation.definition.string.end.slang"


### PR DESCRIPTION
## Summary

Fixes a Slang TextMate grammar leak where a quoted diagnostic string containing a qualified call-like token, such as `_Texture::SampleCmpLevel(...)`, could cause subsequent code to remain highlighted as part of the string/meta scope.

## Root Cause

The `meta.qualified.type.call.slang` lookahead could scan through quoted text after `Shape.dimensions`, find `_Texture::SampleCmpLevel(` inside the string literal, and incorrectly keep the qualified-call scope active. The string rules also had no end-of-line fallback, which made leaks more visible when a string scope failed to close cleanly.

## Changes

- Stop the qualified type-call lookahead at quote characters.
- Let single and double quoted strings terminate at the closing quote or end of line.

## Validation

- Parsed `syntaxes/slang.tmLanguage.json` with `ConvertFrom-Json`.
- Ran a VS Code TextMate tokenizer smoke test confirming the `static_assert` string closes, the following `if` is scoped as `keyword.control.slang`, escaped quotes still work, and unterminated strings do not leak into the next line.