### PR TITLE
Avoid unbounded workspace file preload

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -4,6 +4,7 @@
 **/node_modules/
 !**/node_modules/vue
 test-data/
+out/
 **/tsconfig.json
 esbuild.config.mjs
 **/tsconfig.base.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+# Unreleased
+- Defer native Playground compiler initialization until a related command is used.
+- Bound workspace Slang module preloading by file count and aggregate source size.
+- Read preloaded modules through the workspace file system without opening every file as a text document.
+
 # v2.0.10
 - Update to Slang v2026.8.
 - Highlighting grammar fixes.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ You can specifiy the set of predefined preprocessor macros that the language ser
 By default, the extension will search for all sub directories in the current workspace for an included or imported file. You can specify additional search paths via the `slang.additionalSearchPaths` setting, which will be looked at first. You can also disable the search in workspace directories and make the extension to search only in configured search paths (via `slang.searchInAllWorkspaceDirectories`). The path of the currently opend file will always be used.
 This setting supports VS Code variables such as `${workspaceFolder}`.
 
+### WebAssembly module preload limits
+
+The browser language server and the Compile, Reflection, and Playground commands use a WebAssembly compiler. Because the WebAssembly compiler cannot directly search the workspace file system, the extension preloads workspace `.slang` files so imported modules remain discoverable. The native desktop language server uses the host file system directly and does not require this preload.
+
+The extension stops preloading before it exceeds `slang.workspaceFilePreloadMaxFiles` or `slang.workspaceFilePreloadMaxSizeMB`. Directories containing generated or cached Slang files should be excluded with the VS Code `files.exclude` setting. VS Code does not apply `search.exclude` to extension file-discovery requests.
+
 ### Commit characters for auto completion
 
 Select whether or not to use commit characters to select an auto completion item in addition to pressing the enter key. You can enable commit characters for member completion only or for all types of completion suggestions.

--- a/build_scripts/build-package.sh
+++ b/build_scripts/build-package.sh
@@ -1,4 +1,5 @@
 npm install
+npm test
 npm run compile
 npm install -g @vscode/vsce
 

--- a/client/src/browserClientMain.ts
+++ b/client/src/browserClientMain.ts
@@ -1,10 +1,10 @@
-import { ExtensionContext, Uri, commands, window, workspace } from 'vscode';
+import { ExtensionContext, Uri } from 'vscode';
 import * as vscode from 'vscode';
 import { LanguageClientOptions } from 'vscode-languageclient';
 
 import { LanguageClient } from 'vscode-languageclient/browser';
 import type { CompiledPlayground, CompileRequest, EntrypointsRequest, EntrypointsResult, Result, ServerInitializationOptions, Shader } from 'slang-playground-shared';
-import { getSlangFilesWithContents, sharedActivate } from './sharedClient';
+import { getSlangFilesWithContents, getWorkspaceFilePreloadErrorMessage, sharedActivate } from './sharedClient';
 import { expandSlangSettingsInConfiguration } from './configVariables';
 
 let client: LanguageClient;
@@ -12,11 +12,24 @@ let client: LanguageClient;
 // this method is called when vs code is activated
 export async function activate(context: ExtensionContext) {
 	const documentSelector = [{ language: 'slang' }];
+	let workspaceFiles: { uri: string, content: string }[] = [];
+	try {
+		workspaceFiles = await vscode.window.withProgress(
+			{
+				location: vscode.ProgressLocation.Notification,
+				title: 'Loading Slang workspace modules',
+				cancellable: true,
+			},
+			(_progress, token) => getSlangFilesWithContents(token),
+		);
+	} catch (error) {
+		void vscode.window.showErrorMessage(getWorkspaceFilePreloadErrorMessage(error));
+	}
 
 	const initializationOptions: ServerInitializationOptions = {
 		extensionUri: context.extensionUri.toString(true),
-		workspaceUris: vscode.workspace.workspaceFolders.map(folder => folder.uri.fsPath),
-		files: await getSlangFilesWithContents(),
+		workspaceUris: vscode.workspace.workspaceFolders?.map(folder => folder.uri.fsPath) ?? [],
+		files: workspaceFiles,
 	}
 
 	// Options to control the language client
@@ -54,7 +67,7 @@ export async function activate(context: ExtensionContext) {
 		compilePlayground: function (parameter: CompileRequest): Promise<Result<CompiledPlayground>> {
 			return client.sendRequest('slang/compilePlayground', parameter);
 		},
-		entrypoints: function (parameter: EntrypointsRequest): Promise<EntrypointsResult> {
+		entrypoints: function (parameter: EntrypointsRequest): Promise<Result<EntrypointsResult>> {
 			return client.sendRequest('slang/entrypoints', parameter);
 		}
 	});

--- a/client/src/nativeClientMain.ts
+++ b/client/src/nativeClientMain.ts
@@ -2,7 +2,6 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { ExtensionContext, workspace } from 'vscode';
 
-import * as fs from 'fs';
 import {
 	LanguageClient,
 	LanguageClientOptions,
@@ -13,32 +12,35 @@ import { Worker } from 'worker_threads';
 import { CompiledPlayground, CompileRequest, EntrypointsRequest, EntrypointsResult, Result, ServerInitializationOptions, Shader, WorkerRequest } from 'slang-playground-shared';
 import { getSlangdLocation } from './native/slangd';
 import { SlangSynthesizedCodeProvider } from './native/synth_doc_provider';
-import { getSlangFilesWithContents, sharedActivate } from './sharedClient';
+import { getSlangFilesWithContents, getWorkspaceFilePreloadErrorMessage, sharedActivate } from './sharedClient';
 import { expandSlangSettingsInConfiguration } from './configVariables';
 
-let client: LanguageClient;
-let worker: Worker;
+let client: LanguageClient | undefined;
+let worker: Worker | undefined;
+let workerInitialization: Promise<Worker> | undefined;
+let workerRequestQueue: Promise<void> = Promise.resolve();
 
-
-function sendDidOpenTextDocument(document: vscode.TextDocument) {
+function postDidOpenTextDocument(target: Worker, document: vscode.TextDocument): void {
 	if (document.languageId !== 'slang') return;
-	sendMessageToWorker({
+	target.postMessage({
 		type: 'DidOpenTextDocument',
 		textDocument: {
 			uri: document.uri.toString(),
 			text: document.getText(),
 		}
-	});
+	} satisfies WorkerRequest);
 }
 
+function sendDidOpenTextDocument(document: vscode.TextDocument): void {
+	if (worker) postDidOpenTextDocument(worker, document);
+}
 
-function sendDidChangeTextDocument(event: vscode.TextDocumentChangeEvent) {
-	const document = event.document;
-	if (document.languageId !== 'slang') return;
-	sendMessageToWorker({
+function sendDidChangeTextDocument(event: vscode.TextDocumentChangeEvent): void {
+	if (!worker || event.document.languageId !== 'slang') return;
+	worker.postMessage({
 		type: 'DidChangeTextDocument',
 		textDocument: {
-			uri: document.uri.toString(),
+			uri: event.document.uri.toString(),
 		},
 		contentChanges: event.contentChanges.map(change => ({
 			range: {
@@ -53,7 +55,141 @@ function sendDidChangeTextDocument(event: vscode.TextDocumentChangeEvent) {
 			},
 			text: change.text
 		}))
+	} satisfies WorkerRequest);
+}
+
+async function getEmbeddedSlangFiles(context: ExtensionContext): Promise<{ uri: string, content: string }[]> {
+	const slangDir = vscode.Uri.file(path.join(
+		context.extensionPath,
+		'external',
+		'slang-playground',
+		'engine',
+		'slang-compilation-engine',
+		'src',
+		'slang',
+	));
+	let entries: [string, vscode.FileType][];
+	try {
+		entries = await workspace.fs.readDirectory(slangDir);
+	} catch (error) {
+		if (error instanceof vscode.FileSystemError && error.code === 'FileNotFound') return [];
+		throw error;
+	}
+
+	const decoder = new TextDecoder();
+	const files: { uri: string, content: string }[] = [];
+	for (const [name, type] of entries) {
+		if (type !== vscode.FileType.File || !name.endsWith('.slang')) continue;
+		const uri = vscode.Uri.joinPath(slangDir, name);
+		files.push({ uri: uri.toString(false), content: decoder.decode(await workspace.fs.readFile(uri)) });
+	}
+	return files;
+}
+
+async function createInitializationOptions(
+	context: ExtensionContext,
+	token: vscode.CancellationToken,
+): Promise<ServerInitializationOptions> {
+	const [workspaceFiles, embeddedFiles] = await Promise.all([
+		getSlangFilesWithContents(token),
+		getEmbeddedSlangFiles(context),
+	]);
+	return {
+		extensionUri: context.extensionUri.toString(true),
+		workspaceUris: workspace.workspaceFolders?.map(folder => folder.uri.fsPath) ?? [],
+		files: [...workspaceFiles, ...embeddedFiles],
+	};
+}
+
+function requestWorker<T>(target: Worker, message: WorkerRequest): Promise<T> {
+	return new Promise((resolve, reject) => {
+		const onMessage = (result: T) => {
+			cleanup();
+			resolve(result);
+		};
+		const onError = (error: Error) => {
+			cleanup();
+			reject(error);
+		};
+		const onExit = (code: number) => {
+			cleanup();
+			reject(new Error(`Slang playground worker exited with code ${code}.`));
+		};
+		const cleanup = () => {
+			target.off('message', onMessage);
+			target.off('error', onError);
+			target.off('exit', onExit);
+		};
+
+		target.once('message', onMessage);
+		target.once('error', onError);
+		target.once('exit', onExit);
+		target.postMessage(message);
 	});
+}
+
+async function initializeWorker(context: ExtensionContext): Promise<Worker> {
+	return vscode.window.withProgress(
+		{
+			location: vscode.ProgressLocation.Notification,
+			title: 'Loading Slang workspace modules',
+			cancellable: true,
+		},
+		async (_progress, token) => {
+			const initializationOptions = await createInitializationOptions(context, token);
+			const candidate = new Worker(path.join(context.extensionPath, 'server', 'dist', 'nativeServerMain.js'));
+			const cancellation = token.onCancellationRequested(() => void candidate.terminate());
+			try {
+				const result = await requestWorker<Result<undefined>>(candidate, {
+					type: 'Initialize',
+					initializationOptions,
+				});
+				if (result.succ === false) throw new Error(result.message);
+			} catch (error) {
+				await candidate.terminate();
+				throw error;
+			} finally {
+				cancellation.dispose();
+			}
+
+			worker = candidate;
+			candidate.once('exit', () => {
+				if (worker === candidate) {
+					worker = undefined;
+					workerInitialization = undefined;
+				}
+			});
+			for (const document of workspace.textDocuments) {
+				postDidOpenTextDocument(candidate, document);
+			}
+			return candidate;
+		},
+	);
+}
+
+async function getWorker(context: ExtensionContext): Promise<Worker> {
+	if (worker) return worker;
+	if (!workerInitialization) {
+		workerInitialization = initializeWorker(context).catch(error => {
+			workerInitialization = undefined;
+			throw error;
+		});
+	}
+	return workerInitialization;
+}
+
+function enqueueWorkerRequest<T>(context: ExtensionContext, message: WorkerRequest): Promise<T> {
+	const request = workerRequestQueue.then(async () => requestWorker<T>(await getWorker(context), message));
+	workerRequestQueue = request.then(() => undefined, () => undefined);
+	return request;
+}
+
+function errorResult<T>(error: unknown): Result<T> {
+	return {
+		succ: false,
+		message: getWorkspaceFilePreloadErrorMessage(error),
+		log: error instanceof Error ? error.stack ?? error.message : String(error),
+	};
 }
 
 export async function activate(context: ExtensionContext) {
@@ -65,115 +201,68 @@ export async function activate(context: ExtensionContext) {
 			//	, args: ["--debug"]
 		}
 	};
-	// Options to control the language client
 	const clientOptions: LanguageClientOptions = {
-		// Register the server for plain text documents
 		documentSelector: [{ scheme: 'file', language: 'slang' }],
 		middleware: {
 			workspace: {
 				configuration: async (params, token, next) => {
 					const values = await next(params, token);
-					if (!Array.isArray(values)) {
-						return values;
-					}
-					return values.map((value, index) =>
-						expandSlangSettingsInConfiguration(
-							value,
-							params.items[index]?.section,
-							params.items[index]?.scopeUri,
-						)
-					);
+					if (!Array.isArray(values)) return values;
+					return values.map((value, index) => expandSlangSettingsInConfiguration(
+						value,
+						params.items[index]?.section,
+						params.items[index]?.scopeUri,
+					));
 				},
 			},
 		},
 	};
 
-	// Create the language client and start the client.
 	client = new LanguageClient(
 		'slangLanguageServer',
 		'Slang Language Server',
 		serverOptions,
 		clientOptions
 	);
-	// Start the client. This will also launch the server
-	client.start();
+	await client.start();
 
-	let synthCodeProvider = new SlangSynthesizedCodeProvider();
+	const synthCodeProvider = new SlangSynthesizedCodeProvider();
 	synthCodeProvider.extensionContext = context;
-
 	context.subscriptions.push(
-		workspace.registerTextDocumentContentProvider('slang-synth', synthCodeProvider)
-	);
-
-	// Initialize language server options, including the implicit playground.slang file and other embedded slang files.
-	const slangDir = path.join(context.extensionPath, 'external', 'slang-playground', 'engine', 'slang-compilation-engine', 'src', 'slang');
-	let embeddedSlangFiles: { uri: string, content: string }[] = [];
-	if (fs.existsSync(slangDir)) {
-		const names = fs.readdirSync(slangDir);
-		for (const name of names) {
-			if(!name.endsWith(".slang")) continue;
-			const fileUri = vscode.Uri.file(path.join(slangDir, name));
-			const fileDocument = await vscode.workspace.openTextDocument(fileUri);
-			embeddedSlangFiles.push({ uri: fileUri.toString(), content: fileDocument.getText() });
-		}
-	}
-	const initializationOptions: ServerInitializationOptions = {
-		extensionUri: context.extensionUri.toString(true),
-		workspaceUris: vscode.workspace.workspaceFolders ? vscode.workspace.workspaceFolders.map(folder => folder.uri.fsPath) : [],
-		files: [
-			... await getSlangFilesWithContents(),
-			...embeddedSlangFiles
-		]
-	}
-	worker = new Worker(path.join(context.extensionPath, 'server', 'dist', 'nativeServerMain.js'), {
-		workerData: initializationOptions
-	});
-	sendMessageToWorker({ type: 'Initialize', initializationOptions: initializationOptions });
-
-	// Listen for document open/change events
-	context.subscriptions.push(
-		vscode.workspace.onDidOpenTextDocument(sendDidOpenTextDocument),
-		vscode.workspace.onDidChangeTextDocument(sendDidChangeTextDocument)
+		workspace.registerTextDocumentContentProvider('slang-synth', synthCodeProvider),
+		workspace.onDidOpenTextDocument(sendDidOpenTextDocument),
+		workspace.onDidChangeTextDocument(sendDidChangeTextDocument),
 	);
 
 	sharedActivate(context, {
-		compileShader: function (parameter: CompileRequest): Promise<Result<Shader>> {
-			sendMessageToWorker({ type: 'slang/compile', ...parameter });
-			return new Promise((resolve, reject) => {
-				worker.once('message', (result: Result<Shader>) => {
-					resolve(result);
-				});
-			});
+		compileShader: async (parameter: CompileRequest): Promise<Result<Shader>> => {
+			try {
+				return await enqueueWorkerRequest<Result<Shader>>(context, { type: 'slang/compile', ...parameter });
+			} catch (error) {
+				return errorResult(error);
+			}
 		},
-		compilePlayground: function (parameter: CompileRequest & { uri: string }): Promise<Result<CompiledPlayground>> {
-			sendMessageToWorker({ type: 'slang/compilePlayground', ...parameter });
-			return new Promise((resolve, reject) => {
-				worker.once('message', (result: Result<CompiledPlayground>) => {
-					resolve(result);
-				});
-			});
+		compilePlayground: async (parameter: CompileRequest & { uri: string }): Promise<Result<CompiledPlayground>> => {
+			try {
+				return await enqueueWorkerRequest<Result<CompiledPlayground>>(context, { type: 'slang/compilePlayground', ...parameter });
+			} catch (error) {
+				return errorResult(error);
+			}
 		},
-		entrypoints: function (parameter: EntrypointsRequest): Promise<EntrypointsResult> {
-			sendMessageToWorker({ type: 'slang/entrypoints', ...parameter });
-			return new Promise((resolve, reject) => {
-				worker.once('message', (result: EntrypointsResult) => {
-					resolve(result);
-				});
-			});
-		}
+		entrypoints: async (parameter: EntrypointsRequest): Promise<Result<EntrypointsResult>> => {
+			try {
+				return await enqueueWorkerRequest<Result<EntrypointsResult>>(context, { type: 'slang/entrypoints', ...parameter });
+			} catch (error) {
+				return errorResult(error);
+			}
+		},
 	});
 }
 
-export function sendMessageToWorker(message: WorkerRequest) {
-	worker.postMessage(message);
-}
-
-export function deactivate(): Thenable<void> | undefined {
-	if (worker) {
-		worker.terminate();
-	}
-	if (!client) {
-		return undefined;
-	}
-	client.stop();
+export async function deactivate(): Promise<void> {
+	const target = worker;
+	worker = undefined;
+	workerInitialization = undefined;
+	if (target) await target.terminate();
+	if (client) await client.stop();
 }

--- a/client/src/sharedClient.ts
+++ b/client/src/sharedClient.ts
@@ -1,6 +1,12 @@
 import { ExtensionContext, Uri, commands, window, workspace } from 'vscode';
 import * as vscode from 'vscode';
 
+import {
+	preloadWorkspaceSlangFiles,
+	WorkspaceFilePreloadCancelledError,
+	WorkspaceFilePreloadLimitError,
+} from './workspaceFilePreload';
+
 let slangLogChannel: vscode.OutputChannel | undefined;
 function getSlangLogChannel(): vscode.OutputChannel {
 	if (!slangLogChannel) {
@@ -16,6 +22,9 @@ import { isControllerRendered } from "slang-playground-shared";
 const playgroundPanels = new Map<string, vscode.WebviewPanel>();
 const uniformPanels = new Map<string, vscode.WebviewPanel>();
 const outputPanels = new Map<string, vscode.OutputChannel>();
+
+export const DEFAULT_WORKSPACE_FILE_PRELOAD_MAX_FILES = 10000;
+export const DEFAULT_WORKSPACE_FILE_PRELOAD_MAX_SIZE_MB = 64;
 
 const compileOptions = ['SPIRV', 'HLSL', 'GLSL', 'METAL', 'WGSL', 'CUDA'] as const;
 type LanguageOptions = {
@@ -49,30 +58,71 @@ const compileOptionMap: { [k in (typeof compileOptions)[number]]: LanguageOption
 	}
 }
 
-export async function getSlangFilesWithContents(): Promise<{ uri: string, content: string }[]> {
-	const pattern = '**/*.slang';
-	const files = await vscode.workspace.findFiles(pattern);
-
-	const results: { uri: string, content: string }[] = [];
-
-	for (const uri of files) {
-		try {
-			const document = await vscode.workspace.openTextDocument(uri);
-			results.push({ uri: uri.toString(false), content: document.getText() });
-		} catch (err) {
-			const logChannel = getSlangLogChannel();
-			logChannel.appendLine(`Failed to read ${uri.fsPath}: ${err}`);
-			logChannel.show(true);
-		}
+export function getWorkspaceFilePreloadErrorMessage(error: unknown): string {
+	if (error instanceof WorkspaceFilePreloadLimitError) {
+		const setting = error.kind === 'fileCount'
+			? 'slang.workspaceFilePreloadMaxFiles'
+			: 'slang.workspaceFilePreloadMaxSizeMB';
+		const limit = error.kind === 'fileCount'
+			? `${error.limit} files`
+			: `${Math.floor(error.limit / (1024 * 1024))} MiB`;
+		return `Slang stopped loading workspace modules after exceeding the ${limit} safety limit. `
+			+ `Exclude generated directories with files.exclude or increase ${setting}, then retry the command or reload the window.`;
 	}
+	if (error instanceof WorkspaceFilePreloadCancelledError) {
+		return error.message;
+	}
+	return error instanceof Error ? error.message : String(error);
+}
 
-	return results;
+export async function getSlangFilesWithContents(
+	token?: vscode.CancellationToken,
+): Promise<{ uri: string, content: string }[]> {
+	const config = workspace.getConfiguration('slang');
+	const maxFiles = config.get<number>(
+		'workspaceFilePreloadMaxFiles',
+		DEFAULT_WORKSPACE_FILE_PRELOAD_MAX_FILES,
+	);
+	const maxSizeMB = config.get<number>(
+		'workspaceFilePreloadMaxSizeMB',
+		DEFAULT_WORKSPACE_FILE_PRELOAD_MAX_SIZE_MB,
+	);
+	const openDocumentContents = new Map(
+		workspace.textDocuments
+			.filter(document => document.languageId === 'slang')
+			.map(document => [document.uri.toString(false), document.getText()]),
+	);
+	const result = await preloadWorkspaceSlangFiles(
+		{
+			findSlangFiles: (maxResults, cancellationToken) => workspace.findFiles(
+				'**/*.slang',
+				undefined,
+				maxResults,
+				cancellationToken,
+			),
+			readFile: uri => workspace.fs.readFile(uri),
+			uriKey: uri => uri.toString(false),
+			uriLabel: uri => uri.fsPath,
+		},
+		openDocumentContents,
+		{ maxFiles, maxBytes: maxSizeMB * 1024 * 1024 },
+		token,
+	);
+
+	const logChannel = getSlangLogChannel();
+	logChannel.appendLine(
+		`Loaded ${result.files.length} workspace Slang files (${(result.totalBytes / (1024 * 1024)).toFixed(1)} MiB).`,
+	);
+	for (const failure of result.readErrors) {
+		logChannel.appendLine(`Failed to read ${failure.uri}: ${failure.error}`);
+	}
+	return result.files;
 }
 
 export type SlangHandler = {
 	compileShader: (parameter: CompileRequest) => Promise<Result<Shader>>;
 	compilePlayground: (parameter: CompileRequest & { uri: string }) => Promise<Result<CompiledPlayground>>;
-	entrypoints: (parameter: EntrypointsRequest) => Promise<EntrypointsResult>;
+	entrypoints: (parameter: EntrypointsRequest) => Promise<Result<EntrypointsResult>>;
 };
 
 // this method is called when vs code is activated
@@ -236,8 +286,17 @@ export async function sharedActivate(context: ExtensionContext, slangHandler: Sl
 				sourceCode: userSource,
 				shaderPath: window.activeTextEditor.document.uri.toString(false),
 			}
-			let entrypoints: EntrypointsResult = await slangHandler.entrypoints(parameter);
-			const entrypointSelection = await window.showQuickPick(entrypoints, {
+			const entrypointsResult = await slangHandler.entrypoints(parameter);
+			if (entrypointsResult.succ === false) {
+				vscode.window.showErrorMessage(entrypointsResult.message);
+				if (entrypointsResult.log) {
+					const logChannel = getSlangLogChannel();
+					logChannel.appendLine(entrypointsResult.log);
+					logChannel.show(true);
+				}
+				return;
+			}
+			const entrypointSelection = await window.showQuickPick(entrypointsResult.result, {
 				placeHolder: 'Select a Entrypoint',
 			}) as (typeof compileOptions)[number] | undefined;
 			if (!entrypointSelection) {

--- a/client/src/workspaceFilePreload.test.ts
+++ b/client/src/workspaceFilePreload.test.ts
@@ -1,0 +1,141 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+	preloadWorkspaceSlangFiles,
+	WorkspaceFilePreloadCancelledError,
+	WorkspaceFilePreloadLimitError,
+} from './workspaceFilePreload';
+
+type TestUri = { path: string };
+type TestToken = { isCancellationRequested: boolean };
+
+function createAccess(
+	paths: string[],
+	contents: ReadonlyMap<string, string>,
+	readPaths: string[],
+	observedMaxResults: number[],
+) {
+	return {
+		findSlangFiles: async (maxResults: number, _token?: TestToken) => {
+			observedMaxResults.push(maxResults);
+			return paths.slice(0, maxResults).map(path => ({ path }));
+		},
+		readFile: async (uri: TestUri) => {
+			readPaths.push(uri.path);
+			const content = contents.get(uri.path);
+			if (content === undefined) {
+				throw new Error(`Missing test file: ${uri.path}`);
+			}
+			return new TextEncoder().encode(content);
+		},
+		uriKey: (uri: TestUri) => `file://${uri.path}`,
+		uriLabel: (uri: TestUri) => uri.path,
+	};
+}
+
+test('loads workspace files without opening text documents and preserves open-document contents', async () => {
+	const readPaths: string[] = [];
+	const observedMaxResults: number[] = [];
+	const access = createAccess(
+		['/workspace/main.slang', '/workspace/module.slang'],
+		new Map([
+			['/workspace/main.slang', 'disk main'],
+			['/workspace/module.slang', 'module'],
+		]),
+		readPaths,
+		observedMaxResults,
+	);
+
+	const result = await preloadWorkspaceSlangFiles(
+		access,
+		new Map([['file:///workspace/main.slang', 'unsaved main']]),
+		{ maxFiles: 10, maxBytes: 1024 },
+	);
+
+	assert.deepEqual(observedMaxResults, [11]);
+	assert.deepEqual(readPaths, ['/workspace/module.slang']);
+	assert.deepEqual(result.files, [
+		{ uri: 'file:///workspace/main.slang', content: 'unsaved main' },
+		{ uri: 'file:///workspace/module.slang', content: 'module' },
+	]);
+	assert.equal(result.totalBytes, 18);
+	assert.deepEqual(result.readErrors, []);
+});
+
+test('rejects an oversized file set before reading file contents', async () => {
+	const readPaths: string[] = [];
+	const observedMaxResults: number[] = [];
+	const access = createAccess(
+		['/1.slang', '/2.slang', '/3.slang'],
+		new Map(),
+		readPaths,
+		observedMaxResults,
+	);
+
+	await assert.rejects(
+		preloadWorkspaceSlangFiles(access, new Map(), { maxFiles: 2, maxBytes: 1024 }),
+		(error: unknown) => error instanceof WorkspaceFilePreloadLimitError
+			&& error.kind === 'fileCount'
+			&& error.limit === 2,
+	);
+	assert.deepEqual(observedMaxResults, [3]);
+	assert.deepEqual(readPaths, []);
+});
+
+test('rejects when aggregate source bytes exceed the configured limit', async () => {
+	const access = createAccess(
+		['/1.slang', '/2.slang'],
+		new Map([
+			['/1.slang', '1234'],
+			['/2.slang', '5678'],
+		]),
+		[],
+		[],
+	);
+
+	await assert.rejects(
+		preloadWorkspaceSlangFiles(access, new Map(), { maxFiles: 10, maxBytes: 7 }),
+		(error: unknown) => error instanceof WorkspaceFilePreloadLimitError
+			&& error.kind === 'totalBytes'
+			&& error.observed === 8,
+	);
+});
+
+test('reports unreadable files and continues loading other modules', async () => {
+	const access = createAccess(
+		['/missing.slang', '/module.slang'],
+		new Map([['/module.slang', 'module']]),
+		[],
+		[],
+	);
+
+	const result = await preloadWorkspaceSlangFiles(
+		access,
+		new Map(),
+		{ maxFiles: 10, maxBytes: 1024 },
+	);
+
+	assert.deepEqual(result.files, [{ uri: 'file:///module.slang', content: 'module' }]);
+	assert.equal(result.readErrors.length, 1);
+	assert.equal(result.readErrors[0].uri, '/missing.slang');
+});
+
+test('honors cancellation after workspace discovery', async () => {
+	const token = { isCancellationRequested: false };
+	const access = {
+		findSlangFiles: async (_maxResults: number, receivedToken?: TestToken) => {
+			assert.equal(receivedToken, token);
+			token.isCancellationRequested = true;
+			return [{ path: '/module.slang' }];
+		},
+		readFile: async (_uri: TestUri) => new TextEncoder().encode('module'),
+		uriKey: (uri: TestUri) => `file://${uri.path}`,
+		uriLabel: (uri: TestUri) => uri.path,
+	};
+
+	await assert.rejects(
+		preloadWorkspaceSlangFiles(access, new Map(), { maxFiles: 10, maxBytes: 1024 }, token),
+		WorkspaceFilePreloadCancelledError,
+	);
+});

--- a/client/src/workspaceFilePreload.ts
+++ b/client/src/workspaceFilePreload.ts
@@ -1,0 +1,95 @@
+export interface CancellationTokenLike {
+	readonly isCancellationRequested: boolean;
+}
+
+export interface WorkspaceFileAccess<TUri, TToken extends CancellationTokenLike> {
+	findSlangFiles(maxResults: number, token?: TToken): PromiseLike<readonly TUri[]>;
+	readFile(uri: TUri): PromiseLike<Uint8Array>;
+	uriKey(uri: TUri): string;
+	uriLabel(uri: TUri): string;
+}
+
+export interface WorkspaceFilePreloadLimits {
+	maxFiles: number;
+	maxBytes: number;
+}
+
+export interface WorkspaceFilePreloadResult {
+	files: { uri: string, content: string }[];
+	totalBytes: number;
+	readErrors: { uri: string, error: unknown }[];
+}
+
+export type WorkspaceFilePreloadLimitKind = 'fileCount' | 'totalBytes';
+
+export class WorkspaceFilePreloadLimitError extends Error {
+	constructor(
+		readonly kind: WorkspaceFilePreloadLimitKind,
+		readonly limit: number,
+		readonly observed: number,
+	) {
+		super(kind === 'fileCount'
+			? `The workspace contains more than ${limit} Slang files.`
+			: `The Slang workspace files exceed the ${limit}-byte preload limit.`);
+		this.name = 'WorkspaceFilePreloadLimitError';
+	}
+}
+
+export class WorkspaceFilePreloadCancelledError extends Error {
+	constructor() {
+		super('Loading Slang workspace files was cancelled.');
+		this.name = 'WorkspaceFilePreloadCancelledError';
+	}
+}
+
+function throwIfCancelled(token?: CancellationTokenLike): void {
+	if (token?.isCancellationRequested) {
+		throw new WorkspaceFilePreloadCancelledError();
+	}
+}
+
+export async function preloadWorkspaceSlangFiles<TUri, TToken extends CancellationTokenLike>(
+	access: WorkspaceFileAccess<TUri, TToken>,
+	openDocumentContents: ReadonlyMap<string, string>,
+	limits: WorkspaceFilePreloadLimits,
+	token?: TToken,
+): Promise<WorkspaceFilePreloadResult> {
+	const maxFiles = Math.max(1, Math.floor(limits.maxFiles));
+	const maxBytes = Math.max(1, Math.floor(limits.maxBytes));
+	const uris = await access.findSlangFiles(maxFiles + 1, token);
+
+	throwIfCancelled(token);
+	if (uris.length > maxFiles) {
+		throw new WorkspaceFilePreloadLimitError('fileCount', maxFiles, uris.length);
+	}
+
+	const decoder = new TextDecoder();
+	const encoder = new TextEncoder();
+	const files: { uri: string, content: string }[] = [];
+	const readErrors: { uri: string, error: unknown }[] = [];
+	let totalBytes = 0;
+
+	for (const uri of uris) {
+		throwIfCancelled(token);
+		const key = access.uriKey(uri);
+		try {
+			const openContent = openDocumentContents.get(key);
+			const bytes = openContent === undefined ? await access.readFile(uri) : encoder.encode(openContent);
+			throwIfCancelled(token);
+			const nextTotalBytes = totalBytes + bytes.byteLength;
+			if (nextTotalBytes > maxBytes) {
+				throw new WorkspaceFilePreloadLimitError('totalBytes', maxBytes, nextTotalBytes);
+			}
+			const content = openContent ?? decoder.decode(bytes);
+			totalBytes = nextTotalBytes;
+			files.push({ uri: key, content });
+		} catch (error) {
+			if (error instanceof WorkspaceFilePreloadLimitError) {
+				throw error;
+			}
+			readErrors.push({ uri: access.uriLabel(uri), error });
+		}
+	}
+
+	return { files, totalBytes, readErrors };
+}

--- a/package.json
+++ b/package.json
@@ -266,7 +266,7 @@
         "preinstall": "npm --prefix ./external/slang-playground run build-engine",
         "vscode:prepublish": "npm run compile",
         "compile": "node esbuild.config.mjs",
-        "test": "esbuild client/src/workspaceFilePreload.test.ts --bundle --platform=node --format=cjs --outfile=node_modules/.cache/slang-vscode-extension/workspaceFilePreload.test.cjs && node --test node_modules/.cache/slang-vscode-extension/workspaceFilePreload.test.cjs",
+        "test": "esbuild client/src/workspaceFilePreload.test.ts --bundle --platform=node --format=cjs --outfile=out/workspaceFilePreload.test.cjs && node --test out/workspaceFilePreload.test.cjs",
         "watch": "esbuild --config=esbuild.config.mjs --watch",
         "package": "node esbuild.config.mjs",
         "chrome": "npm run compile && vscode-test-web --browserType=chromium --browserOption=--enable-unsafe-webgpu --extensionDevelopmentPath=. ./test-data"

--- a/package.json
+++ b/package.json
@@ -140,6 +140,20 @@
                     "default": [],
                     "description": "The language server will search for the included or imported file in these additional directories first. If not found, the server will look in all sub directories in the current workspace (if enabled by the setting). Supports VS Code variables such as ${workspaceFolder}."
                 },
+                "slang.workspaceFilePreloadMaxFiles": {
+                    "scope": "window",
+                    "type": "integer",
+                    "minimum": 1,
+                    "default": 10000,
+                    "markdownDescription": "Maximum number of workspace `.slang` files to preload for WebAssembly module discovery. Files excluded by `files.exclude` are not counted. Increase this limit with care because the file contents are copied into WebAssembly memory."
+                },
+                "slang.workspaceFilePreloadMaxSizeMB": {
+                    "scope": "window",
+                    "type": "integer",
+                    "minimum": 1,
+                    "default": 64,
+                    "markdownDescription": "Maximum aggregate size in MiB of workspace `.slang` files to preload for WebAssembly module discovery. Increase this limit with care because the file contents are copied into WebAssembly memory."
+                },
                 "slang.enableCommitCharactersInAutoCompletion": {
                     "scope": "window",
                     "type": "string",
@@ -252,6 +266,7 @@
         "preinstall": "npm --prefix ./external/slang-playground run build-engine",
         "vscode:prepublish": "npm run compile",
         "compile": "node esbuild.config.mjs",
+        "test": "esbuild client/src/workspaceFilePreload.test.ts --bundle --platform=node --format=cjs --outfile=node_modules/.cache/slang-vscode-extension/workspaceFilePreload.test.cjs && node --test node_modules/.cache/slang-vscode-extension/workspaceFilePreload.test.cjs",
         "watch": "esbuild --config=esbuild.config.mjs --watch",
         "package": "node esbuild.config.mjs",
         "chrome": "npm run compile && vscode-test-web --browserType=chromium --browserOption=--enable-unsafe-webgpu --extensionDevelopmentPath=. ./test-data"

--- a/server/src/browserServerMain.ts
+++ b/server/src/browserServerMain.ts
@@ -92,6 +92,7 @@ connection.onInitialize(async (_params: InitializeParams): Promise<InitializeRes
         const emscriptenURI = getEmscriptenURI(file.uri, initializationOptions.workspaceUris);
         loadFileIntoEmscriptenFS(emscriptenURI, file.content);
     }
+    initializationOptions.files = [];
 
     return {
         capabilities: {

--- a/server/src/nativeServerMain.ts
+++ b/server/src/nativeServerMain.ts
@@ -88,6 +88,7 @@ async function initialize(params: WorkerRequest & { type: 'Initialize' }): Promi
         const emscriptenURI = getEmscriptenURI(file.uri, initializationOptions.workspaceUris);
         loadFileIntoEmscriptenFS(emscriptenURI, file.content);
     }
+    initializationOptions.files = [];
 
     return {
         succ: true,
@@ -144,7 +145,8 @@ async function slangCompilePlayground(params: WorkerRequest & { type: 'slang/com
     
     const compilationResult = await compiler.compile(params, shaderPath, initializationOptions.workspaceUris, spirvTools);
     if (compilationResult.succ === false) {
-        return compilationResult;
+        parentPort!.postMessage(compilationResult);
+        return;
     }
     parentPort!.postMessage(compilePlayground(compilationResult.result, params.uri));
 }


### PR DESCRIPTION
Fixes #73.

## Summary

- keep native `slangd` activation independent of workspace source preloading;
- initialize the native WebAssembly Playground/compiler worker lazily on the first Compile, Reflection, or Playground command;
- retain the preload required for WebAssembly module discovery, while limiting it to 10,000 files and 64 MiB by default;
- discover at most `maxFiles + 1` sources, read them sequentially through `workspace.fs`, and preserve the contents of already-open/dirty Slang documents;
- honor cancellation and report an actionable error identifying `files.exclude` and the setting that was exceeded;
- release the initialization source array after copying files into MEMFS;
- serialize native worker requests so concurrent commands cannot consume one another's responses.

The preload remains intentional in the browser extension and in the native Compile/Reflection/Playground path. Slang module imports do not require a build-system module graph, while the WebAssembly compiler cannot search the host workspace directly. The native language server does not have that restriction.

Two settings allow unusual, intentionally large workspaces to opt in to higher limits:

- `slang.workspaceFilePreloadMaxFiles`
- `slang.workspaceFilePreloadMaxSizeMB`

Passing `undefined` as the `workspace.findFiles()` exclude argument intentionally applies VS Code's `files.exclude`. The README calls out that `search.exclude` is not applied by this API.

## Additional correctness fixes

The native Playground worker previously did not post a response when compilation failed. That would leave the awaiting command unresolved; it also deadlocks serialized requests. The worker now posts the failed `Result` before returning.

## Verification

- `npm test` (5 focused preload tests: dirty-document override, early count limit, aggregate-byte limit, read failure, cancellation)
- `tsc --noEmit -p client/tsconfig.json`
- complete `esbuild.config.mjs` production build for native client/server, browser client/server, and both webviews
- `git diff --check`